### PR TITLE
changes to final report messages

### DIFF
--- a/src/edu/umn/cs/melt/copper/ant/CopperAntTask.java
+++ b/src/edu/umn/cs/melt/copper/ant/CopperAntTask.java
@@ -218,7 +218,7 @@ public class CopperAntTask extends Task
 			params.setCustomSwitch(customSwitch,customSwitches.get(customSwitch));
 		}
 		
-		System.out.println("------------------------------------------------------------\nCompiling " + inputs.size() + " input file" + (inputs.size() == 1 ? "" : "s") + ":");
+		System.out.println("============================================================\nCompiling " + inputs.size() + " input file" + (inputs.size() == 1 ? "" : "s") + ":");
 		for(Pair<String,Object> input : inputs) System.out.println("\t" + input.first());
 		
 		int errorlevel = 1;

--- a/src/edu/umn/cs/melt/copper/ant/CopperAntTask.java
+++ b/src/edu/umn/cs/melt/copper/ant/CopperAntTask.java
@@ -218,7 +218,7 @@ public class CopperAntTask extends Task
 			params.setCustomSwitch(customSwitch,customSwitches.get(customSwitch));
 		}
 		
-		System.out.println("Compiling " + inputs.size() + " input file" + (inputs.size() == 1 ? "" : "s") + ":");
+		System.out.println("------------------------------------------------------------\nCompiling " + inputs.size() + " input file" + (inputs.size() == 1 ? "" : "s") + ":");
 		for(Pair<String,Object> input : inputs) System.out.println("\t" + input.first());
 		
 		int errorlevel = 1;

--- a/src/edu/umn/cs/melt/copper/compiletime/logging/messages/FinalReportMessage.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/logging/messages/FinalReportMessage.java
@@ -43,7 +43,7 @@ public class FinalReportMessage implements CompilerLogMessage
 		StringBuffer rv = new StringBuffer();
 		rv.append("-------------\nFinal report:\n-------------\n");
 		
-		rv.append("Parser and scanner specifcation\n   has " + stats.terminalCount + " terminal" + ((stats.terminalCount == 1) ? "" : "s") + ", " + stats.nonterminalCount + " nonterminal" + ((stats.nonterminalCount == 1) ? "" : "s") + ", " + stats.productionCount + " productions,\n   and " + stats.disambiguationFunctionCount + " disambiguation function" + ((stats.disambiguationFunctionCount == 1) ? "" : "s") + " declared,\n");
+		rv.append("Parser and scanner specification\n   has " + stats.terminalCount + " terminal" + ((stats.terminalCount == 1) ? "" : "s") + ", " + stats.nonterminalCount + " nonterminal" + ((stats.nonterminalCount == 1) ? "" : "s") + ", " + stats.productionCount + " productions,\n   and " + stats.disambiguationFunctionCount + " disambiguation function" + ((stats.disambiguationFunctionCount == 1) ? "" : "s") + " declared,\n");
 		rv.append("   producing " + stats.parseStateCount + " unique parse state" + ((stats.parseStateCount == 1) ? "" : "s") + "\n");
 		rv.append("   and " + stats.scannerStateCount + " unique scanner state" + ((stats.scannerStateCount == 1) ? "" : "s") + ".\n");
 		rv.append(stats.uselessNTs.cardinality() + " useless nonterminal" + ((stats.uselessNTs.cardinality() == 1) ? "" : "s") + ".\n");

--- a/src/edu/umn/cs/melt/copper/compiletime/logging/messages/FinalReportMessage.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/logging/messages/FinalReportMessage.java
@@ -41,9 +41,9 @@ public class FinalReportMessage implements CompilerLogMessage
 	public String toString()
 	{
 		StringBuffer rv = new StringBuffer();
-		rv.append("----------\nFinal report.\n");
+		rv.append("-------------\nFinal report:\n-------------\n");
 		
-		rv.append("Grammar has " + stats.terminalCount + " terminal" + ((stats.terminalCount == 1) ? "" : "s") + ", " + stats.nonterminalCount + " nonterminal" + ((stats.nonterminalCount == 1) ? "" : "s") + ", " + stats.productionCount + " productions,\n   and " + stats.disambiguationFunctionCount + " disambiguation function" + ((stats.disambiguationFunctionCount == 1) ? "" : "s") + " declared,\n");
+		rv.append("Parser and scanner specifcation\n   has " + stats.terminalCount + " terminal" + ((stats.terminalCount == 1) ? "" : "s") + ", " + stats.nonterminalCount + " nonterminal" + ((stats.nonterminalCount == 1) ? "" : "s") + ", " + stats.productionCount + " productions,\n   and " + stats.disambiguationFunctionCount + " disambiguation function" + ((stats.disambiguationFunctionCount == 1) ? "" : "s") + " declared,\n");
 		rv.append("   producing " + stats.parseStateCount + " unique parse state" + ((stats.parseStateCount == 1) ? "" : "s") + "\n");
 		rv.append("   and " + stats.scannerStateCount + " unique scanner state" + ((stats.scannerStateCount == 1) ? "" : "s") + ".\n");
 		rv.append(stats.uselessNTs.cardinality() + " useless nonterminal" + ((stats.uselessNTs.cardinality() == 1) ? "" : "s") + ".\n");
@@ -53,7 +53,7 @@ public class FinalReportMessage implements CompilerLogMessage
 		}
 		else
 		{
-			rv.append(stats.unresolvedParseTableConflictCount + " unresolved parse table conflict" + ((stats.unresolvedParseTableConflictCount == 1) ? "" : "s") + "\n   " + stats.shiftReduceParseTableConflictCount + " shift/reduce conflicts, " + stats.reduceReduceParseTableConflictCount + " reduce/reduce, " + (stats.parseTableConflictCount - stats.unresolvedParseTableConflictCount) + " resolved.\n");
+			rv.append(stats.unresolvedParseTableConflictCount + " unresolved parse table conflict" + ((stats.unresolvedParseTableConflictCount == 1) ? "" : "s") + ":\n   " + stats.shiftReduceParseTableConflictCount + " shift/reduce conflicts, " + stats.reduceReduceParseTableConflictCount + " reduce/reduce, " + (stats.parseTableConflictCount - stats.unresolvedParseTableConflictCount) + " resolved.\n");
 		}
 		if(stats.lexicalAmbiguityCount == 0)
 		{
@@ -61,7 +61,7 @@ public class FinalReportMessage implements CompilerLogMessage
 		}
 		else
 		{
-			rv.append((stats.lexicalAmbiguityCount - (stats.contextResolvedLexicalAmbiguityCount + stats.disambiguationFunctionResolvedLexicalAmbiguityCount)) + " unresolved lexical ambiguit" + ((stats.lexicalAmbiguityCount == 1) ? "y" : "ies") + "\n" );
+			rv.append((stats.lexicalAmbiguityCount - (stats.contextResolvedLexicalAmbiguityCount + stats.disambiguationFunctionResolvedLexicalAmbiguityCount)) + " unresolved lexical ambiguit" + ((stats.lexicalAmbiguityCount == 1) ? "y" : "ies") + ":\n" );
 			rv.append("   " + stats.contextResolvedLexicalAmbiguityCount + " resolved by context, " + stats.disambiguationFunctionResolvedLexicalAmbiguityCount + " by disambiguation function/group.");
 		}
 		if(stats.codeOutput)

--- a/src/edu/umn/cs/melt/copper/compiletime/logging/messages/FinalReportMessage.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/logging/messages/FinalReportMessage.java
@@ -41,11 +41,11 @@ public class FinalReportMessage implements CompilerLogMessage
 	public String toString()
 	{
 		StringBuffer rv = new StringBuffer();
-		rv.append("===== FINAL REPORT =====\n");
+		rv.append("----------\nFinal report.\n");
 		
-		rv.append(stats.terminalCount + " terminal" + ((stats.terminalCount == 1) ? "" : "s") + ", " + stats.nonterminalCount + " nonterminal" + ((stats.nonterminalCount == 1) ? "" : "s") + ",\n" + stats.productionCount + " productions, and " + stats.disambiguationFunctionCount + " disambiguation function" + ((stats.disambiguationFunctionCount == 1) ? "" : "s") + " declared,\n");
-		rv.append("producing " + stats.parseStateCount + " unique parse state" + ((stats.parseStateCount == 1) ? "" : "s") + "\n");
-		rv.append("and " + stats.scannerStateCount + " unique scanner state" + ((stats.scannerStateCount == 1) ? "" : "s") + ".\n");
+		rv.append("Grammar has " + stats.terminalCount + " terminal" + ((stats.terminalCount == 1) ? "" : "s") + ", " + stats.nonterminalCount + " nonterminal" + ((stats.nonterminalCount == 1) ? "" : "s") + ", " + stats.productionCount + " productions,\n   and " + stats.disambiguationFunctionCount + " disambiguation function" + ((stats.disambiguationFunctionCount == 1) ? "" : "s") + " declared,\n");
+		rv.append("   producing " + stats.parseStateCount + " unique parse state" + ((stats.parseStateCount == 1) ? "" : "s") + "\n");
+		rv.append("   and " + stats.scannerStateCount + " unique scanner state" + ((stats.scannerStateCount == 1) ? "" : "s") + ".\n");
 		rv.append(stats.uselessNTs.cardinality() + " useless nonterminal" + ((stats.uselessNTs.cardinality() == 1) ? "" : "s") + ".\n");
 		if(stats.parseTableConflictCount == 0)
 		{
@@ -53,7 +53,7 @@ public class FinalReportMessage implements CompilerLogMessage
 		}
 		else
 		{
-			rv.append(stats.parseTableConflictCount + " parse table conflict" + ((stats.parseTableConflictCount == 1) ? "" : "s") + " detected\n   (" + stats.shiftReduceParseTableConflictCount + " shift/reduce, " + stats.reduceReduceParseTableConflictCount + " reduce/reduce); " + (stats.parseTableConflictCount - stats.unresolvedParseTableConflictCount) + " resolved.\n");
+			rv.append(stats.unresolvedParseTableConflictCount + " unresolved parse table conflict" + ((stats.unresolvedParseTableConflictCount == 1) ? "" : "s") + "\n   " + stats.shiftReduceParseTableConflictCount + " shift/reduce conflicts, " + stats.reduceReduceParseTableConflictCount + " reduce/reduce, " + (stats.parseTableConflictCount - stats.unresolvedParseTableConflictCount) + " resolved.\n");
 		}
 		if(stats.lexicalAmbiguityCount == 0)
 		{
@@ -61,8 +61,8 @@ public class FinalReportMessage implements CompilerLogMessage
 		}
 		else
 		{
-			rv.append(stats.lexicalAmbiguityCount + " lexical ambiguit" + ((stats.lexicalAmbiguityCount == 1) ? "y" : "ies") + " detected; " + (stats.contextResolvedLexicalAmbiguityCount + stats.disambiguationFunctionResolvedLexicalAmbiguityCount) + " resolved,\n");
-			rv.append("   " + stats.contextResolvedLexicalAmbiguityCount + " by context, " + stats.disambiguationFunctionResolvedLexicalAmbiguityCount + " by disambiguation function/group.");
+			rv.append((stats.lexicalAmbiguityCount - (stats.contextResolvedLexicalAmbiguityCount + stats.disambiguationFunctionResolvedLexicalAmbiguityCount)) + " unresolved lexical ambiguit" + ((stats.lexicalAmbiguityCount == 1) ? "y" : "ies") + "\n" );
+			rv.append("   " + stats.contextResolvedLexicalAmbiguityCount + " resolved by context, " + stats.disambiguationFunctionResolvedLexicalAmbiguityCount + " by disambiguation function/group.");
 		}
 		if(stats.codeOutput)
 		{


### PR DESCRIPTION
I have attempted to improve the readability of Copper's compile-time messages.  There were 2 concerns that I had.
First, when multiple grammars are run through Copper the results from the Ant script flowed together in a way that made it not so easy to see where the report from one grammar ended and the next began.  The "=====" in the final report message looked, to me at least, like significant separators indicating the break between processing one grammar and the next.  But this wan't the case.
Second, knowing that all parse table conflicts or and lexical ambiguities required comparing the number of conflicts (ambiguities) with the number that were resolved.  Now, it just print "0 unresolved ..." and it is, again in my opinion, easier to see at a glance that everything just worked.  In doing this I modified the stats about number of terminals, NTs, productions, etc so that no numbers are printed in the first column.  This way one can just scan for 0's in the the first column to know that things worked.  

Below is a sample output in the new format, followed by the current format.

August, if you agree that this is an improvement then please merge this pull request, otherwise create a comment with your concerns or suggested other changes.  Thanks.


```
copper_mda:
   [copper] ------------------------------------------------------------
   [copper] Compiling 1 input file:
   [copper] 	Parser_edu_umn_cs_melt_exts_ableC_regex_mda_test_testMatching.copper
   [copper] ----------
   [copper] Final report.
   [copper] Grammar has 193 terminals, 106 nonterminals, 433 productions,
   [copper]    and 2 disambiguation functions declared,
   [copper]    producing 750 unique parse states
   [copper]    and 816 unique scanner states.
   [copper] 0 useless nonterminals.
   [copper] 0 unresolved parse table conflicts
   [copper]    3 shift/reduce conflicts, 1 reduce/reduce, 4 resolved.
   [copper] 0 unresolved lexical ambiguities
   [copper]    80 resolved by context, 3 by disambiguation function/group.
   [copper] No parser code output.
   [copper] ----------
   [copper] Modular determinism analysis passed.
   [copper] 0 nonterminals with follow spillage.
   [copper] Composed parser has 749 host states, 1 extension state,
   [copper] 0 new-host states, and 0 unpartitionable states.
   [copper] ------------------------------------------------------------
   [copper] Compiling 1 input file:
   [copper] 	Parser_edu_umn_cs_melt_exts_ableC_regex_mda_test_testLiterals.copper
   [copper] ----------
   [copper] Final report.
   [copper] Grammar has 207 terminals, 114 nonterminals, 454 productions,
   [copper]    and 2 disambiguation functions declared,
   [copper]    producing 783 unique parse states
   [copper]    and 819 unique scanner states.
   [copper] 0 useless nonterminals.
```

The current (to be replaced) format:
```
copper_mda:
   [copper] Compiling 1 input file:
   [copper] 	Parser_edu_umn_cs_melt_exts_ableC_regex_mda_test_testMatching.copper
   [copper] ===== FINAL REPORT =====
   [copper] 193 terminals, 106 nonterminals,
   [copper] 433 productions, and 2 disambiguation functions declared,
   [copper] producing 750 unique parse states
   [copper] and 816 unique scanner states.
   [copper] 0 useless nonterminals.
   [copper] 4 parse table conflicts detected
   [copper]    (3 shift/reduce, 1 reduce/reduce); 4 resolved.
   [copper] 83 lexical ambiguities detected; 83 resolved,
   [copper]    80 by context, 3 by disambiguation function/group.
   [copper] No parser code output.
   [copper] ----------
   [copper] Modular determinism analysis passed.
   [copper] 0 nonterminals with follow spillage.
   [copper] Composed parser has 749 host states, 1 extension state,
   [copper] 0 new-host states, and 0 unpartitionable states.
   [copper] Compiling 1 input file:
   [copper] 	Parser_edu_umn_cs_melt_exts_ableC_regex_mda_test_testLiterals.copper
   [copper] ===== FINAL REPORT =====
   [copper] 207 terminals, 114 nonterminals,
   [copper] 454 productions, and 2 disambiguation functions declared,
   [copper] producing 783 unique parse states
   [copper] and 819 unique scanner states.
   [copper] 0 useless nonterminals.
```