### PR TITLE
Feature/flagparse

### DIFF
--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/CustomSwitcher.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/CustomSwitcher.java
@@ -1,0 +1,34 @@
+package edu.umn.cs.melt.copper.compiletime.pipeline;
+
+import java.util.Set;
+
+import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
+import edu.umn.cs.melt.copper.runtime.auxiliary.Pair;
+
+/**
+ * The interface for classes containing custom switches
+ * @author Patrick Stephen
+ */
+public interface CustomSwitcher
+{
+	/**
+	 * Returns a set of "custom" switches accepted by this switcher.
+	 */
+	public Set<String> getCustomSwitches();
+	
+	/**
+	 * Returns a summary of the "custom" switches accepted by this switcher,
+	 * to be printed when the "usage" message is displayed.
+	 */
+	public String customSwitchUsage();
+
+	/**
+	 * Processes a "custom" parameter from the command line, converting it
+	 * into an entry in the given object for input arguments.
+	 * @param args The object in which the processed custom switch will be placed.
+	 * @param flag The parsed flag and value given to said flag
+	 * @return Whether this flag was recognized by this custom switcher
+	 */
+	public boolean processCustomSwitch(ParserCompilerParameters args, Pair<String,String> flag);
+	
+}

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/ParserBeanCompiler.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/ParserBeanCompiler.java
@@ -28,21 +28,19 @@ import edu.umn.cs.melt.copper.compiletime.spec.numeric.GrammarStatistics;
 import edu.umn.cs.melt.copper.compiletime.spec.numeric.PSSymbolTable;
 import edu.umn.cs.melt.copper.compiletime.spec.numeric.ParserSpec;
 import edu.umn.cs.melt.copper.main.CopperDumpControl;
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Set;
 
 /**
  * @author Kevin Viratyosin
  *
  * Extracted from StandardSpecCompiler
  */
-public abstract class ParserBeanCompiler<RETURNDATA> implements SpecCompiler<ParserBean,RETURNDATA> {
+public abstract class ParserBeanCompiler<RETURNDATA> extends ZeroSwitcher implements SpecCompiler<ParserBean,RETURNDATA> {
     protected boolean succeeded;
     protected int errorlevel;
     protected PSSymbolTable symbolTable;
@@ -295,20 +293,5 @@ public abstract class ParserBeanCompiler<RETURNDATA> implements SpecCompiler<Par
                 }
             }
         }
-    }
-
-    @Override
-    public Set<String> getCustomSwitches() {
-        return null;
-    }
-
-    @Override
-    public String customSwitchUsage() {
-        return null;
-    }
-
-    @Override
-    public int processCustomSwitch(ParserCompilerParameters args, String[] cmdline, int index) {
-        return -1;
     }
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/ParserFragmentsDeserializer.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/ParserFragmentsDeserializer.java
@@ -13,12 +13,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
-import java.util.Set;
 
 /**
  * @author Kevin Viratyosin
  */
-public class ParserFragmentsDeserializer implements SpecParser<ParserFragments> {
+public class ParserFragmentsDeserializer extends ZeroSwitcher implements SpecParser<ParserFragments> {
     public ParserFragmentsDeserializer(ParserCompilerParameters args) {
     }
 
@@ -81,20 +80,5 @@ public class ParserFragmentsDeserializer implements SpecParser<ParserFragments> 
             logger.logError(new GenericMessage(CompilerLevel.QUIET, "Error in deserialization fragment in \"" + filename + "\": " + e.getMessage(), true, true));
             return null;
         }
-    }
-
-    @Override
-    public Set<String> getCustomSwitches() {
-        return null;
-    }
-
-    @Override
-    public String customSwitchUsage() {
-        return "";
-    }
-
-    @Override
-    public int processCustomSwitch(ParserCompilerParameters args, String[] cmdline, int index) {
-        return -1;
     }
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/ParserFragmentsPasser.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/ParserFragmentsPasser.java
@@ -3,12 +3,10 @@ package edu.umn.cs.melt.copper.compiletime.pipeline;
 import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
-import java.util.Set;
-
 /**
  * @author Kevin Viratyosin
  */
-public class ParserFragmentsPasser implements SpecCompiler<ParserFragments, ParserFragments> {
+public class ParserFragmentsPasser extends ZeroSwitcher implements SpecCompiler<ParserFragments, ParserFragments> {
     public ParserFragmentsPasser(ParserCompilerParameters args) {
         // intentionally left blank; meant to keep consistency with the use of the StandardPipeline
     }
@@ -16,20 +14,5 @@ public class ParserFragmentsPasser implements SpecCompiler<ParserFragments, Pars
     @Override
     public ParserFragments compileParser(ParserFragments spec, SpecCompilerParameters args) throws CopperException {
         return spec;
-    }
-
-    @Override
-    public Set<String> getCustomSwitches() {
-        return null;
-    }
-
-    @Override
-    public String customSwitchUsage() {
-        return "";
-    }
-
-    @Override
-    public int processCustomSwitch(ParserCompilerParameters args, String[] cmdline, int index) {
-        return -1;
     }
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/Pipeline.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/Pipeline.java
@@ -1,7 +1,6 @@
 package edu.umn.cs.melt.copper.compiletime.pipeline;
 
 import java.io.IOException;
-import java.util.Set;
 
 import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
@@ -13,7 +12,7 @@ import edu.umn.cs.melt.copper.runtime.logging.CopperException;
  * @author August Schwerdfeger &lt;<a href="mailto:schwerdf@cs.umn.edu">schwerdf@cs.umn.edu</a>&gt;
  *
  */
-public interface Pipeline
+public interface Pipeline extends CustomSwitcher
 {
 	/**
 	 * Executes the pipeline.
@@ -22,26 +21,4 @@ public interface Pipeline
 	 */
 	public int execute(ParserCompilerParameters args)
 	throws IOException,CopperException;
-	
-	/**
-	 * Returns a set of "custom" switches accepted by this pipeline.
-	 */
-	public Set<String> getCustomSwitches();
-	
-	/**
-	 * Returns a summary of the "custom" switches accepted by this pipeline,
-	 * to be printed when the "usage" message is displayed.
-	 */
-	public String customSwitchUsage();
-
-	/**
-	 * Processes a "custom" switch from the command line, converting it
-	 * into an entry in the given object for input arguments. 
-	 * @param args The object in which the processed custom switch will be placed.
-	 * @param cmdline The full command line.
-	 * @param index The array index at which the custom switch starts.
-	 * @return The array index immediately following the whole custom switch (e.g., {@code index+1} for
-	 *         a plain boolean switch), or -1 if the parameter was not recognized by this pipeline.
-	 */
-	public int processCustomSwitch(ParserCompilerParameters args,String[] cmdline,int index);
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/SourceBuilder.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/SourceBuilder.java
@@ -1,8 +1,5 @@
 package edu.umn.cs.melt.copper.compiletime.pipeline;
 
-import java.util.Set;
-
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
 /**
@@ -10,30 +7,8 @@ import edu.umn.cs.melt.copper.runtime.logging.CopperException;
  * @see StandardPipeline
  * @author August Schwerdfeger &lt;<a href="mailto:schwerdf@cs.umn.edu">schwerdf@cs.umn.edu</a>&gt;
  */
-public interface SourceBuilder<IN>
+public interface SourceBuilder<IN> extends CustomSwitcher
 {
 	public int buildSource(IN constructs,SourceBuilderParameters args)
 	throws CopperException;
-	
-	/**
-	 * Returns a set of "custom" switches accepted by this source builder.
-	 */
-	public Set<String> getCustomSwitches();
-
-	/**
-	 * Returns a summary of the "custom" switches accepted by this source builder,
-	 * to be printed when the "usage" message is displayed.
-	 */
-	public String customSwitchUsage();
-
-	/**
-	 * Processes a "custom" parameter from the command line, converting it
-	 * into an entry in the given object for input arguments.
-	 * @param args The object in which the processed custom switch will be placed.
-	 * @param cmdline The full command line.
-	 * @param index The array index at which the custom switch starts.
-	 * @return The array index immediately following the whole custom switch (e.g., {@code index+1} for
-	 *         a plain boolean switch), or -1 if the parameter was not recognized by this source builder.
-	 */
-	public int processCustomSwitch(ParserCompilerParameters args,String[] cmdline,int index);
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/SpecCompiler.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/SpecCompiler.java
@@ -1,8 +1,5 @@
 package edu.umn.cs.melt.copper.compiletime.pipeline;
 
-import java.util.Set;
-
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
 /**
@@ -10,31 +7,8 @@ import edu.umn.cs.melt.copper.runtime.logging.CopperException;
  * @see StandardPipeline
  * @author August Schwerdfeger &lt;<a href="mailto:schwerdf@cs.umn.edu">schwerdf@cs.umn.edu</a>&gt;
  */
-public interface SpecCompiler<IN, OUT>
+public interface SpecCompiler<IN, OUT> extends CustomSwitcher
 {
 	public OUT compileParser(IN spec,SpecCompilerParameters args)
 	throws CopperException;
-	
-	/**
-	 * Returns a set of "custom" switches accepted by this spec compiler.
-	 */
-	public Set<String> getCustomSwitches();
-	
-	/**
-	 * Returns a summary of the "custom" switches accepted by this spec compiler,
-	 * to be printed when the "usage" message is displayed.
-	 */
-	public String customSwitchUsage();
-
-	/**
-	 * Processes a "custom" parameter from the command line, converting it
-	 * into an entry in the given object for input arguments.
-	 * @param args The object in which the processed custom switch will be placed.
-	 * @param cmdline The full command line.
-	 * @param index The array index at which the custom switch starts.
-	 * @return The array index immediately following the whole custom switch (e.g., {@code index+1} for
-	 *         a plain boolean switch), or -1 if the parameter was not recognized by this spec compiler.
-	 */
-	public int processCustomSwitch(ParserCompilerParameters args,String[] cmdline,int index);
-
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/SpecParser.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/SpecParser.java
@@ -1,9 +1,7 @@
 package edu.umn.cs.melt.copper.compiletime.pipeline;
 
 import java.io.IOException;
-import java.util.Set;
 
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
 /**
@@ -11,31 +9,8 @@ import edu.umn.cs.melt.copper.runtime.logging.CopperException;
  * @see StandardPipeline
  * @author August Schwerdfeger &lt;<a href="mailto:schwerdf@cs.umn.edu">schwerdf@cs.umn.edu</a>&gt;
  */
-public interface SpecParser<OUT>
+public interface SpecParser<OUT> extends CustomSwitcher
 {
 	public OUT parseSpec(SpecParserParameters args)
 	throws IOException,CopperException;
-	
-	/**
-	 * Returns a set of "custom" switches accepted by this spec parser.
-	 */
-	public Set<String> getCustomSwitches();
-	
-	/**
-	 * Returns a summary of the "custom" switches accepted by this spec parser,
-	 * to be printed when the "usage" message is displayed.
-	 */
-	public String customSwitchUsage();
-
-	/**
-	 * Processes a "custom" parameter from the command line, converting it
-	 * into an entry in the given object for input arguments.
-	 * @param args The object in which the processed custom switch will be placed.
-	 * @param cmdline The full command line.
-	 * @param index The array index at which the custom switch starts.
-	 * @return The array index immediately following the whole custom switch (e.g., {@code index+1} for
-	 *         a plain boolean switch), or -1 if the parameter was not recognized by this spec parser.
-	 */
-	public int processCustomSwitch(ParserCompilerParameters args,String[] cmdline,int index);
-	
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/StandardPipeline.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/StandardPipeline.java
@@ -203,16 +203,11 @@ public class StandardPipeline<SCIN,SCOUT> implements Pipeline,SpecParser<SCIN>,S
 	}
 
 	@Override
-	public int processCustomSwitch(ParserCompilerParameters args,
-			String[] cmdline, int index)
+	public boolean processCustomSwitch(ParserCompilerParameters args, Pair<String,String> flag)
 	{
-		int rv;
-		rv = specParser.processCustomSwitch(args,cmdline,index);
-		if(rv != -1) return rv;
-		rv = specCompiler.processCustomSwitch(args,cmdline,index);
-		if(rv != -1) return rv;
-		rv = sourceBuilder.processCustomSwitch(args,cmdline,index);
-		if(rv != -1) return rv;
-		return -1;
+		if (specParser.processCustomSwitch(args,flag)) return true;
+		if (specCompiler.processCustomSwitch(args,flag)) return true;
+		if (sourceBuilder.processCustomSwitch(args,flag)) return true;
+		return false;
 	}
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/ZeroSwitcher.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/ZeroSwitcher.java
@@ -12,14 +12,31 @@ import java.util.HashSet;
  */
 public abstract class ZeroSwitcher implements CustomSwitcher {
 
+    /**
+	 * Returns a set of "custom" switches accepted by this switcher. 
+     * As a zero switcher, this returns an empty set.
+	 */
     public Set<String> getCustomSwitches() {
         return new HashSet<String>();
     }
 
+    /**
+	 * Returns a summary of the "custom" switches accepted by this switcher,
+	 * to be printed when the "usage" message is displayed. As a zero switcher,
+     * this returns an empty string.
+	 */
     public String customSwitchUsage() {
         return "";
     }
 
+    /**
+	 * Processes a "custom" parameter from the command line, converting it
+	 * into an entry in the given object for input arguments. As a zero switcher,
+     * this accepts no flags and returns false. 
+	 * @param args The object in which the processed custom switch will be placed.
+	 * @param flag The parsed flag and value given to said flag
+	 * @return Whether this flag was recognized by this custom switcher
+	 */
     public boolean processCustomSwitch(ParserCompilerParameters args, Pair<String,String> flag) {
         return false;
     }

--- a/src/edu/umn/cs/melt/copper/compiletime/pipeline/ZeroSwitcher.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/pipeline/ZeroSwitcher.java
@@ -1,0 +1,26 @@
+package edu.umn.cs.melt.copper.compiletime.pipeline;
+
+import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
+import edu.umn.cs.melt.copper.runtime.auxiliary.Pair;
+
+import java.util.Set;
+import java.util.HashSet;
+
+/**
+ * A zero switcher returns zero values when queried for its custom switches.
+ * @author Patrick Stephen
+ */
+public abstract class ZeroSwitcher implements CustomSwitcher {
+
+    public Set<String> getCustomSwitches() {
+        return new HashSet<String>();
+    }
+
+    public String customSwitchUsage() {
+        return "";
+    }
+
+    public boolean processCustomSwitch(ParserCompilerParameters args, Pair<String,String> flag) {
+        return false;
+    }
+}

--- a/src/edu/umn/cs/melt/copper/compiletime/skins/cup/CupParsingProcess.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/skins/cup/CupParsingProcess.java
@@ -4,7 +4,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.Set;
 
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLevel;
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLogger;
@@ -12,11 +11,11 @@ import edu.umn.cs.melt.copper.compiletime.logging.messages.InterfaceErrorMessage
 import edu.umn.cs.melt.copper.compiletime.pipeline.AuxiliaryMethods;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SpecParser;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SpecParserParameters;
+import edu.umn.cs.melt.copper.compiletime.pipeline.ZeroSwitcher;
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ParserBean;
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.auxiliary.Pair;
 
-public class CupParsingProcess implements SpecParser<ParserBean>
+public class CupParsingProcess extends ZeroSwitcher implements SpecParser<ParserBean>
 {
 	@Override
 	public ParserBean parseSpec(SpecParserParameters args)
@@ -67,24 +66,5 @@ public class CupParsingProcess implements SpecParser<ParserBean>
 		if(args.getPackageName() != null) spec.setPackageDecl(args.getPackageName());
 		if(args.getParserName() != null && !args.getParserName().equals("")) spec.setClassName(args.getParserName());
 		return spec;
-	}
-
-	@Override
-	public Set<String> getCustomSwitches()
-	{
-		return null;
-	}
-
-	@Override
-	public String customSwitchUsage()
-	{
-		return "";
-	}
-
-	@Override
-	public int processCustomSwitch(ParserCompilerParameters args,
-			String[] cmdline, int index)
-	{
-		return -1;
 	}
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/skins/xml/XMLParsingProcess.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/skins/xml/XMLParsingProcess.java
@@ -5,7 +5,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.Set;
 
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLevel;
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLogger;
@@ -13,12 +12,12 @@ import edu.umn.cs.melt.copper.compiletime.logging.messages.InterfaceErrorMessage
 import edu.umn.cs.melt.copper.compiletime.pipeline.AuxiliaryMethods;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SpecParser;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SpecParserParameters;
+import edu.umn.cs.melt.copper.compiletime.pipeline.ZeroSwitcher;
 import edu.umn.cs.melt.copper.compiletime.spec.grammarbeans.ParserBean;
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.auxiliary.Pair;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
-public class XMLParsingProcess implements SpecParser<ParserBean>
+public class XMLParsingProcess extends ZeroSwitcher implements SpecParser<ParserBean>
 {
 	@Override
 	public ParserBean parseSpec(SpecParserParameters args)
@@ -69,24 +68,5 @@ public class XMLParsingProcess implements SpecParser<ParserBean>
 		}
 		
 		return spec;
-	}
-
-	@Override
-	public Set<String> getCustomSwitches()
-	{
-		return null;
-	}
-
-	@Override
-	public String customSwitchUsage()
-	{
-		return "";
-	}
-
-	@Override
-	public int processCustomSwitch(ParserCompilerParameters args,
-			String[] cmdline, int index)
-	{
-		return -1;
 	}
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/srcbuilders/fragment/FragmentSerializationProcess.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/srcbuilders/fragment/FragmentSerializationProcess.java
@@ -8,20 +8,19 @@ import edu.umn.cs.melt.copper.compiletime.pipeline.AuxiliaryMethods;
 import edu.umn.cs.melt.copper.compiletime.pipeline.FragmentGeneratorReturnData;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SourceBuilder;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SourceBuilderParameters;
+import edu.umn.cs.melt.copper.compiletime.pipeline.ZeroSwitcher;
 import edu.umn.cs.melt.copper.main.CopperIOType;
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.util.Set;
 
 /**
  * @author Kevin Viratyosin
  */
-public class FragmentSerializationProcess implements SourceBuilder<FragmentGeneratorReturnData> {
+public class FragmentSerializationProcess extends ZeroSwitcher implements SourceBuilder<FragmentGeneratorReturnData> {
     @Override
     public int buildSource(FragmentGeneratorReturnData constructs, SourceBuilderParameters args) throws CopperException {
         CompilerLogger logger = AuxiliaryMethods.getOrMakeLogger(args);
@@ -53,20 +52,5 @@ public class FragmentSerializationProcess implements SourceBuilder<FragmentGener
             logger.logError(new GenericMessage(CompilerLevel.QUIET, "I/O error in fragment serialization: " + e.getMessage(),true,true));
             return 1;
         }
-    }
-
-    @Override
-    public Set<String> getCustomSwitches() {
-        return null;
-    }
-
-    @Override
-    public String customSwitchUsage() {
-        return "";
-    }
-
-    @Override
-    public int processCustomSwitch(ParserCompilerParameters args, String[] cmdline, int index) {
-        return -1;
     }
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/srcbuilders/fragment/ParserFragmentCompositionProcess.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/srcbuilders/fragment/ParserFragmentCompositionProcess.java
@@ -8,18 +8,18 @@ import edu.umn.cs.melt.copper.compiletime.pipeline.AuxiliaryMethods;
 import edu.umn.cs.melt.copper.compiletime.pipeline.ParserFragments;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SourceBuilder;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SourceBuilderParameters;
+import edu.umn.cs.melt.copper.compiletime.pipeline.ZeroSwitcher;
 import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Set;
 
 /**
  * @author Kevin Viratyosin
  */
-public class ParserFragmentCompositionProcess implements SourceBuilder<ParserFragments> {
+public class ParserFragmentCompositionProcess extends ZeroSwitcher implements SourceBuilder<ParserFragments> {
     public ParserFragmentCompositionProcess(ParserCompilerParameters args) {
     }
 
@@ -80,20 +80,5 @@ public class ParserFragmentCompositionProcess implements SourceBuilder<ParserFra
         logger.flush();
 
         return 0;
-    }
-
-    @Override
-    public Set<String> getCustomSwitches() {
-        return null;
-    }
-
-    @Override
-    public String customSwitchUsage() {
-        return null;
-    }
-
-    @Override
-    public int processCustomSwitch(ParserCompilerParameters args, String[] cmdline, int index) {
-        return -1;
     }
 }

--- a/src/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFACompilationProcess.java
+++ b/src/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFACompilationProcess.java
@@ -3,7 +3,6 @@ package edu.umn.cs.melt.copper.compiletime.srcbuilders.single;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Set;
 
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLevel;
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLogger;
@@ -12,12 +11,12 @@ import edu.umn.cs.melt.copper.compiletime.logging.messages.GenericMessage;
 import edu.umn.cs.melt.copper.compiletime.logging.messages.TimingMessage;
 import edu.umn.cs.melt.copper.compiletime.pipeline.AuxiliaryMethods;
 import edu.umn.cs.melt.copper.compiletime.pipeline.StandardSpecCompilerReturnData;
+import edu.umn.cs.melt.copper.compiletime.pipeline.ZeroSwitcher;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SourceBuilder;
 import edu.umn.cs.melt.copper.compiletime.pipeline.SourceBuilderParameters;
-import edu.umn.cs.melt.copper.main.ParserCompilerParameters;
 import edu.umn.cs.melt.copper.runtime.logging.CopperException;
 
-public class SingleDFACompilationProcess implements SourceBuilder<StandardSpecCompilerReturnData>
+public class SingleDFACompilationProcess extends ZeroSwitcher implements SourceBuilder<StandardSpecCompilerReturnData>
 {
 	boolean outputSource;
 	
@@ -106,24 +105,5 @@ public class SingleDFACompilationProcess implements SourceBuilder<StandardSpecCo
 		logger.flush();
 		
 		return c.errorlevel;
-	}
-
-	@Override
-	public Set<String> getCustomSwitches()
-	{
-		return null;
-	}
-
-	@Override
-	public String customSwitchUsage()
-	{
-		return "";
-	}
-
-	@Override
-	public int processCustomSwitch(ParserCompilerParameters args,
-			String[] cmdline, int index)
-	{
-		return -1;
 	}
 }

--- a/src/edu/umn/cs/melt/copper/legacy/compiletime/abstractsyntax/grammar/LegacyPipeline.java
+++ b/src/edu/umn/cs/melt/copper/legacy/compiletime/abstractsyntax/grammar/LegacyPipeline.java
@@ -507,25 +507,21 @@ public class LegacyPipeline implements Pipeline
 	}
 
 	@Override
-	public int processCustomSwitch(ParserCompilerParameters args, String[] cmdline, int index)
+	public boolean processCustomSwitch(ParserCompilerParameters args, Pair<String,String> flag)
 	{
-		if(cmdline[index].equals("-pretty"))
-		{
-			args.setCustomSwitch("isPretty",true);
-			return index+1;
+		switch (flag.first()) {
+			case "-pretty":
+				args.setCustomSwitch("isPretty",true);
+				return true;
+			case "-gatherstats":
+				if(args.getCustomSwitch("gatherStatistics",String.class,"ERROR").equals("ERROR")) args.setCustomSwitch("runtimeQuietLevel","NOTA_BENE");
+				args.setCustomSwitch("gatherStatistics",true);
+				return true;
+			case "-runv":
+				args.setCustomSwitch("runtimeQuietLevel","INFO");
+				return true;
 		}
-		else if(cmdline[index].equals("-gatherstats"))
-		{
-			if(args.getCustomSwitch("gatherStatistics",String.class,"ERROR").equals("ERROR")) args.setCustomSwitch("runtimeQuietLevel","NOTA_BENE");
-			args.setCustomSwitch("gatherStatistics",true);
-			return index+1;
-		}
-		else if(cmdline[index].equals("-runv"))
-		{
-			args.setCustomSwitch("runtimeQuietLevel","INFO");
-			return index+1;
-		}
-		else return -1;		
+		return false;
 	}
 
 	@Override

--- a/src/edu/umn/cs/melt/copper/legacy/compiletime/abstractsyntax/grammar/LegacyPipeline.java
+++ b/src/edu/umn/cs/melt/copper/legacy/compiletime/abstractsyntax/grammar/LegacyPipeline.java
@@ -509,19 +509,17 @@ public class LegacyPipeline implements Pipeline
 	@Override
 	public boolean processCustomSwitch(ParserCompilerParameters args, Pair<String,String> flag)
 	{
-		switch (flag.first()) {
-			case "-pretty":
-				args.setCustomSwitch("isPretty",true);
-				return true;
-			case "-gatherstats":
-				if(args.getCustomSwitch("gatherStatistics",String.class,"ERROR").equals("ERROR")) args.setCustomSwitch("runtimeQuietLevel","NOTA_BENE");
-				args.setCustomSwitch("gatherStatistics",true);
-				return true;
-			case "-runv":
-				args.setCustomSwitch("runtimeQuietLevel","INFO");
-				return true;
+		if (flag.first() == "-pretty") {
+			args.setCustomSwitch("isPretty",true);
+		} else if (flag.first() == "-gatherstats") {
+			if(args.getCustomSwitch("gatherStatistics",String.class,"ERROR").equals("ERROR")) args.setCustomSwitch("runtimeQuietLevel","NOTA_BENE");
+			args.setCustomSwitch("gatherStatistics",true);
+		} else if (flag.first() == "-runv") {
+			args.setCustomSwitch("runtimeQuietLevel","INFO");
+		} else {
+			return false;
 		}
-		return false;
+		return true;
 	}
 
 	@Override

--- a/src/edu/umn/cs/melt/copper/main/FlagParser.java
+++ b/src/edu/umn/cs/melt/copper/main/FlagParser.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import edu.umn.cs.melt.copper.runtime.auxiliary.Pair;
 
 /**
- * FlagParser takes in 
+ * FlagParser processes []String args flags and inputs
+ * and stores them in three lists: inputs, known flags, and unknown flags.
+ * @author Patrick Stephen
  */
 public class FlagParser
 {

--- a/src/edu/umn/cs/melt/copper/main/FlagParser.java
+++ b/src/edu/umn/cs/melt/copper/main/FlagParser.java
@@ -1,6 +1,7 @@
 package edu.umn.cs.melt.copper.main;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,25 +15,47 @@ public class FlagParser
 
     private Map<String,String> flagMap;
     public List<Pair<String,String>> customFlags;
-    public ArrayList<Pair<String,Object>> files;
+    public ArrayList<Pair<String,Object>> inputs;
 
     public FlagParser(Map<String,String> map)
     {
         this.flagMap = map;
         this.customFlags = new ArrayList<>();
-        this.files = new ArrayList<>();
+        this.inputs = new ArrayList<>();
     }
 
-    public boolean IsFlag(String key)
+    public FlagParser(List<String> list) 
+    {
+        this.flagMap = new HashMap<>();
+        for (String flag : list) {
+            this.flagMap.put(flag, null);
+        }
+        this.customFlags = new ArrayList<>();
+        this.inputs = new ArrayList<>();
+    }
+
+    /**
+     * isFlag returns whether the input key is part of the expected flags for
+     * this parser.
+     * @param key the flag
+     * @return whether the input is an expected flag for this parser
+     */
+    public boolean isFlag(String key)
     {
         return flagMap.containsKey(key);
     }
 
-    public boolean Parse(String[] args) {
+    /**
+     * parse processes input strings as flags and inputs. Inputs are expected
+     * to follow flags, and flags are all expected to begin with '-'.
+     * @param args The arguments to parse
+     * @return boolean success of the parse 
+     */
+    public boolean parse(String[] args) {
         int i = 0;
         
         while (i < args.length) {
-            // At this point, if we see something that is not a flag, we're at files
+            // At this point, if we see something that is not a flag, we're at inputs
             if (args[i].charAt(0) != '-') {
                 break;
             }
@@ -45,7 +68,10 @@ public class FlagParser
                 val = args[i+1];
                 i++;
             }
-            if (IsFlag(key)) {
+            // We have known and custom flags. If we know about this flag 
+            // (this parser was initialized with the flag), then we set the
+            // known flag, else we set it as a custom flag.
+            if (isFlag(key)) {
                 flagMap.put(key, val);
             } else {
                 customFlags.add(Pair.cons(key,val));
@@ -53,18 +79,23 @@ public class FlagParser
         }
 
         while (i < args.length) {
-            files.add(Pair.cons(args[i], (Object) args[i]));
+            inputs.add(Pair.cons(args[i], (Object) args[i]));
             i++;
         }
 
         return true;
     }
 
-    public Pair<Boolean,String> Get(String key) 
+    /**
+     * get returns whether this parser has seen the input in its
+     * known flags. 
+     * @param key The flag to check
+     * @return Pair<IsSet,value>. If the value sent back is null, IsSet will be false
+     */
+    public Pair<Boolean,String> get(String key) 
     {
         String val = flagMap.get(key);
-        boolean isSet = val != null;
-        return Pair.cons(isSet,val);
+        return Pair.cons(val != null,val);
     }
 
 }

--- a/src/edu/umn/cs/melt/copper/main/FlagParser.java
+++ b/src/edu/umn/cs/melt/copper/main/FlagParser.java
@@ -1,0 +1,70 @@
+package edu.umn.cs.melt.copper.main;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import edu.umn.cs.melt.copper.runtime.auxiliary.Pair;
+
+/**
+ * FlagParser takes in 
+ */
+public class FlagParser
+{
+
+    private Map<String,String> flagMap;
+    public List<Pair<String,String>> customFlags;
+    public ArrayList<Pair<String,Object>> files;
+
+    public FlagParser(Map<String,String> map)
+    {
+        this.flagMap = map;
+        this.customFlags = new ArrayList<>();
+        this.files = new ArrayList<>();
+    }
+
+    public boolean IsFlag(String key)
+    {
+        return flagMap.containsKey(key);
+    }
+
+    public boolean Parse(String[] args) {
+        int i = 0;
+        
+        while (i < args.length) {
+            // At this point, if we see something that is not a flag, we're at files
+            if (args[i].charAt(0) != '-') {
+                break;
+            }
+            String key = args[i];
+            String val = "<set>";
+            // Flags can either be -flag -flag2 or -flag <val> -flag2 <val>
+            // We check if the value after this is another flag, or a value.
+            i++;
+            if (i < args.length && args[i].charAt(0) != '-') {
+                val = args[i+1];
+                i++;
+            }
+            if (IsFlag(key)) {
+                flagMap.put(key, val);
+            } else {
+                customFlags.add(Pair.cons(key,val));
+            }
+        }
+
+        while (i < args.length) {
+            files.add(Pair.cons(args[i], (Object) args[i]));
+            i++;
+        }
+
+        return true;
+    }
+
+    public Pair<Boolean,String> Get(String key) 
+    {
+        String val = flagMap.get(key);
+        boolean isSet = val != null;
+        return Pair.cons(isSet,val);
+    }
+
+}

--- a/src/edu/umn/cs/melt/copper/main/FlagParser.java
+++ b/src/edu/umn/cs/melt/copper/main/FlagParser.java
@@ -20,18 +20,18 @@ public class FlagParser
     public FlagParser(Map<String,String> map)
     {
         this.flagMap = map;
-        this.customFlags = new ArrayList<>();
-        this.inputs = new ArrayList<>();
+        this.customFlags = new ArrayList<Pair<String,String>>();
+        this.inputs = new ArrayList<Pair<String,Object>>();
     }
 
     public FlagParser(List<String> list) 
     {
-        this.flagMap = new HashMap<>();
+        this.flagMap = new HashMap<String,String>();
         for (String flag : list) {
             this.flagMap.put(flag, null);
         }
-        this.customFlags = new ArrayList<>();
-        this.inputs = new ArrayList<>();
+        this.customFlags = new ArrayList<Pair<String,String>>();
+        this.inputs = new ArrayList<Pair<String,Object>>();
     }
 
     /**

--- a/src/edu/umn/cs/melt/copper/main/ParserCompiler.java
+++ b/src/edu/umn/cs/melt/copper/main/ParserCompiler.java
@@ -5,8 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.Properties;
 
 import edu.umn.cs.melt.copper.compiletime.logging.CompilerLevel;
@@ -59,26 +58,26 @@ public class ParserCompiler
 		VERSION = (version == null || !version.matches("[0-9\\.]+")) ? "unknown" : version; 
 		BUILD = (build == null || !build.matches("[0-9]{8}-[0-9]{4}")) ? "unknown" : build; 
 		
-		Map<String,String> flags = new HashMap<>();
+		ArrayList<String> flags = new ArrayList<String>();
 		// Todo: bake usage into flag parser
-		flags.put("-?", null);
-		flags.put("-version", null);
-		flags.put("-o", null);
-		flags.put("-q", null);
-		flags.put("-v", null);
-		flags.put("-vv", null);
-		flags.put("-dump", null);
-		flags.put("-errordump", null);
-		flags.put("-skin", null);
-		flags.put("-engine", null);
-		flags.put("-pipeline", null);
-		flags.put("-mda", null);
-		flags.put("-logfile", null);
-		flags.put("-dumpfile",null);
-		flags.put("-dumptype", null);
-		flags.put("-avoidRecompile", null);
-		flags.put("-package", null);
-		flags.put("-parser", null);
+		flags.add("-?");
+		flags.add("-version");
+		flags.add("-o");
+		flags.add("-q");
+		flags.add("-v");
+		flags.add("-vv");
+		flags.add("-dump");
+		flags.add("-errordump");
+		flags.add("-skin");
+		flags.add("-engine");
+		flags.add("-pipeline");
+		flags.add("-mda");
+		flags.add("-logfile");
+		flags.add("-dumpfile");
+		flags.add("-dumptype");
+		flags.add("-avoidRecompile");
+		flags.add("-package");
+		flags.add("-parser");
 		flagParser = new FlagParser(flags);
 	}
 	private static void versionMessage(ParserCompilerParameters args)

--- a/src/edu/umn/cs/melt/copper/main/ParserCompiler.java
+++ b/src/edu/umn/cs/melt/copper/main/ParserCompiler.java
@@ -257,36 +257,36 @@ public class ParserCompiler
 		{
 			usageMessageNoError(null);
 		}
-
-		boolean success = flagParser.Parse(args);
+		
+		boolean success = flagParser.parse(args);
 		if (!success) {
 			usageMessageError(null);
 		}
 	
-		boolean displayHelp = flagParser.Get("-?").first();
-		boolean displayVersion = flagParser.Get("-version").first();
-		boolean runMDA = flagParser.Get("-mda").first();;
-		boolean avoidRecompile = flagParser.Get("-avoidRecompile").first();
+		boolean displayHelp = flagParser.get("-?").first();
+		boolean displayVersion = flagParser.get("-version").first();
+		boolean runMDA = flagParser.get("-mda").first();;
+		boolean avoidRecompile = flagParser.get("-avoidRecompile").first();
 
-		String logFile = flagParser.Get("-logfile").second();
-		String packageDecl = flagParser.Get("-package").second();
-		String parserName = flagParser.Get("-parser").second();
-		String output = flagParser.Get("-o").second();
-		String dumpFile = flagParser.Get("-dumpfile").second();
+		String logFile = flagParser.get("-logfile").second();
+		String packageDecl = flagParser.get("-package").second();
+		String parserName = flagParser.get("-parser").second();
+		String output = flagParser.get("-o").second();
+		String dumpFile = flagParser.get("-dumpfile").second();
 
 		CompilerLevel quietLevel = getDefaultQuietLevel();
-		if (flagParser.Get("-vv").first()) {
+		if (flagParser.get("-vv").first()) {
 			quietLevel = CompilerLevel.VERY_VERBOSE;
-		} else if (flagParser.Get("-v").first()) {
+		} else if (flagParser.get("-v").first()) {
 			quietLevel = CompilerLevel.VERBOSE;
-		} else if ((flagParser.Get("-q").first())) {
+		} else if ((flagParser.get("-q").first())) {
 			quietLevel = CompilerLevel.QUIET;
 		}
 
 		CopperDumpControl dumpControl = CopperDumpControl.OFF;
-		if (flagParser.Get("-dump").first()) {
+		if (flagParser.get("-dump").first()) {
 			dumpControl = CopperDumpControl.ON;
-		} else if (flagParser.Get("-errordump").first()) {
+		} else if (flagParser.get("-errordump").first()) {
 			dumpControl = CopperDumpControl.ERROR_ONLY;
 		}
 
@@ -298,7 +298,7 @@ public class ParserCompiler
 		CopperPipelineType.initTable();
 		CopperPipelineType usePipeline = getDefaultPipeline();
 
-		Pair<Boolean,String> skin = flagParser.Get("-skin");
+		Pair<Boolean,String> skin = flagParser.get("-skin");
 		if (skin.first()) {
 			if (!CopperSkinType.contains(skin.second())) {
 				usageMessageError(null);
@@ -306,7 +306,7 @@ public class ParserCompiler
 			useSkin = CopperSkinType.fromString(skin.second());
 		}
 
-		Pair<Boolean,String> pipe = flagParser.Get("-pipeline");
+		Pair<Boolean,String> pipe = flagParser.get("-pipeline");
 		if (skin.first()) {
 			if (!CopperPipelineType.contains(pipe.second())) {
 				usageMessageError(null);
@@ -314,7 +314,7 @@ public class ParserCompiler
 			usePipeline = CopperPipelineType.fromString(pipe.second());
 		}
 
-		Pair<Boolean,String> engine = flagParser.Get("-engine");
+		Pair<Boolean,String> engine = flagParser.get("-engine");
 		if (engine.first()) {
 			if (!CopperEngineType.contains(engine.second())) {
 				usageMessageError(null);
@@ -322,7 +322,7 @@ public class ParserCompiler
 			useEngine = CopperEngineType.fromString(engine.second());
 		}
 
-		Pair<Boolean,String> dumpF = flagParser.Get("-dumptype");
+		Pair<Boolean,String> dumpF = flagParser.get("-dumptype");
 		if (engine.first()) {
 			if (!CopperDumpType.contains(dumpF.second())) {
 				usageMessageError(null);
@@ -394,7 +394,7 @@ public class ParserCompiler
 			if (!pipeline.processCustomSwitch(argTable,flag)) break;
 		}
 
-		argTable.setInputs(flagParser.files);
+		argTable.setInputs(flagParser.inputs);
 				
 		int errorlevel = 1;
 		

--- a/src/edu/umn/cs/melt/copper/runtime/RunParser.java
+++ b/src/edu/umn/cs/melt/copper/runtime/RunParser.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.reflect.Method;
 
 import edu.umn.cs.melt.copper.runtime.engines.CopperParser;
 import edu.umn.cs.melt.copper.runtime.logging.CopperParserException;

--- a/src/edu/umn/cs/melt/copper/runtime/RunParser.java
+++ b/src/edu/umn/cs/melt/copper/runtime/RunParser.java
@@ -4,7 +4,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.lang.reflect.Method;
 
 import edu.umn.cs.melt.copper.runtime.engines.CopperParser;
 import edu.umn.cs.melt.copper.runtime.logging.CopperParserException;


### PR DESCRIPTION
This makes three significant changes:

1. `ParserCompiler`'s method of evaluating input flags is changed. Previously it would iterate over the input arguments and switch on each of them to linearly check if they matched any known flags. This implementation initializes a `FlagParser` class that can distinguish between known and unknown flags, and parses all flags and inputs only once. In the future, the flag parser could also be told about usage for each flag individually.

2.  Because custom flags are no longer processed in order, but are pre-processed, the signature of `processCustomSwitch` was changed to match the new custom switch set. This changes functionality so that custom switches no longer have the ability to maneuver themselves around the argument list, but have to match either the `-flag value` or boolean `-flag` pattern. This does not break any existing custom switchers, as far as I found.

3. In changing the  signature of `processCustomSwitch`, I recognized that all but one type that used custom switches had identical behavior-- not accepting them. I removed duplicate code in several classes, all of the form of rejecting custom switches, and baked that functionality into the `ZeroSwitcher` abstract class, which implements the new interface `CustomSwitcher`.

There is one other minor functionality change, and that is if you were to pass in multiple flags for the same setting, previously whatever the last flag was would be the one used. In this implementation there is an implicit hierarchy of which flags for each setting are checked and used first, so if you gave `-vv -v -q`, the compiler class would choose -vv, as it is the "safest" choice. I have no attachment to the hierarchies in place, and could also rework this to use the old functionality if it is desired (at the loss of some generality in the FlagParser class).

There are also likely style concerns, I haven't done Java recently but I tried to mimic the style of the project as it exists. I am concerned about the placement of the three new classes in this respect-- I have no attachment to their current packages. 

Following these changes, I tested each individual test in the copper/test directory and all of silver's tests, and everything passed or failed as (what seemed to be, in the case of the copper tests) appropriate. 



