### PR TITLE
Introduce Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ try {
   stage("Silver integration") {
     // Let's test against the current, (though possibly unstable!), development version of Silver
     // (We need scripts like 'deep-rebuild' so we can't use silver-latest.tar.gz.)
-    sh "cp -r $MELT_SILVER_WORKSPACE silver-latest"
+    sh "cp -r $MELT_SILVER_WORKSPACE/* silver-latest"
     
     sh "cp target/Copper*.jar silver-latest/jars/"
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ try {
   stage("Build") {
 
     // Immediate failure for notification testing
+    sh "printenv"
     sh "false"
 
     // Checks out this repo and branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,13 +29,16 @@ try {
     // Checks out this repo and branch
     checkout scm
 
-    def M2_REPO = pwd() + "/.m2repo"
     // -B  Run in non-interactive (batch) mode
     // -e  Produce execution error messages
     // -fae  Only fail the build afterwards; allow all non-impacted builds to continue
     // -Dmaven.test.failure.ignore=true  Ignore test failures (We look at them with the junit command later)
+    sh "mvn clean verify -B -e -fae -Dmaven.test.failure.ignore=true"
+
+    // I decided to remove this.
+    // This means our cache is persistent, but also that it might grow unbounded, since nothing prunes it.
+    //def M2_REPO = pwd() + "/.m2repo"
     // -Dmaven.repo.local=$M2_REPO  Use a local maven repo instead of in the homedir.
-    sh "mvn clean verify -B -e -fae -Dmaven.test.failure.ignore=true -Dmaven.repo.local=$M2_REPO"
 
     junit allowEmptyResults: true, testResults:"**/target/*-reports/*.xml"
   }
@@ -43,7 +46,8 @@ try {
   stage("Silver integration") {
     // Let's test against the current, (though possibly unstable!), development version of Silver
     // (We need scripts like 'deep-rebuild' so we can't use silver-latest.tar.gz.)
-    sh "cp -r $MELT_SILVER_WORKSPACE/* silver-latest"
+    sh "rm -rf ./silver-latest || true"
+    sh "cp -r $MELT_SILVER_WORKSPACE silver-latest"
     
     sh "cp target/Copper*.jar silver-latest/jars/"
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,10 +26,6 @@ try {
 
   stage("Build") {
 
-    // Immediate failure for notification testing
-    sh "printenv"
-    sh "false"
-
     // Checks out this repo and branch
     checkout scm
 
@@ -75,17 +71,16 @@ try {
 
 } finally {
   
-  // testing...
-  if( (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master' || true) &&
+  // August requests email notifications only for develop/master, not feature branches.
+  if( (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master') &&
       currentBuild.result == 'FAILURE') {
-    def subject = "Build failed: '${env.JOB_NAME}' (${env.BRANCH_NAME}) [${env.BUILD_NUMBER}]"
-    //def body = """<a href='${env.BUILD_URL}'>${env.BUILD_URL}</a>"""
+    // env.JOB_NAME gives things like 'melt-umn/copper/feature%2Fjenkins' which is ugly
+    def job = "copper"
+    def subject = "Build failed: '${job}' (${env.BRANCH_NAME}) [${env.BUILD_NUMBER}]"
     def body = """${env.BUILD_URL}"""
     emailext(
       subject: subject,
-      //mimeType: 'text/html',
       body: body,
-      to: 'tedinski@cs.umn.edu',
       recipientProviders: [[$class: 'CulpritsRecipientProvider']]
     )
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,9 @@ properties([
 ])
 
 // Location where we dump stable artifacts: jars, tarballs
-def MELT_ARTIFACTS = '/export/scratch/melt-jenkins/custom-stable-dump/'
+def MELT_ARTIFACTS = '/export/scratch/melt-jenkins/custom-stable-dump'
+// Location of a Silver checkout (w/ jars)
+def MELT_SILVER_WORKSPACE = '/export/scratch/melt-jenkins/custom-silver'
 
 node {
 
@@ -39,18 +41,18 @@ try {
   }
   
   stage("Silver integration") {
-    // Let's test against the current, stable, development version of Silver
-    // TODO: maybe we should test against current non-stable version?
-    // i.e. /export/scratch/melt-jenkins/custom-silver ?
-    def SILVER_LATEST = "$MELT_ARTIFACTS/silver-latest.tar.gz"
-    // Unpacks to 'silver-latest/'
-    sh "tar zxvf $SILVER_LATEST"
+    // Let's test against the current, (though possibly unstable!), development version of Silver
+    // (We need scripts like 'deep-rebuild' so we can't use silver-latest.tar.gz.)
+    sh "cp -r $MELT_SILVER_WORKSPACE silver-latest"
     
     sh "cp target/Copper*.jar silver-latest/jars/"
     
     dir('silver-latest') {
       sh "./deep-rebuild"
     }
+
+    // Common case: clean up if successful
+    sh "rm -rf ./silver-latest"
   }
   
   if (env.BRANCH_NAME == 'develop') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,69 @@
+// An excellent resource is Maven's own Jenkinsfile: https://github.com/apache/maven/blob/master/Jenkinsfile
+// This is also helpful: https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md
+
+properties([
+  /* If we don't set this, everything is preserved forever.
+     We don't bother discarding build logs (because they're small),
+     but if this job keeps artifacts, we ask them to only stick around
+     for awhile. */
+  [ $class: 'BuildDiscarderProperty',
+    strategy:
+      [ $class: 'LogRotator',
+        artifactDaysToKeepStr: '120',
+        artifactNumToKeepStr: '20'
+      ]
+  ]
+])
+
+// Location where we dump stable artifacts: jars, tarballs
+def MELT_ARTIFACTS = '/export/scratch/melt-jenkins/custom-stable-dump/'
+
+node {
+
+try {
+
+  stage("Build") {
+
+    // Checks out this repo and branch
+    checkout scm
+
+    def M2_REPO = pwd() + "/.m2repo"
+    // -B  Run in non-interactive (batch) mode
+    // -e  Produce execution error messages
+    // -fae  Only fail the build afterwards; allow all non-impacted builds to continue
+    // -Dmaven.test.failure.ignore=true  Ignore test failures (We look at them with the junit command later)
+    // -Dmaven.repo.local=$M2_REPO  Use a local maven repo instead of in the homedir.
+    sh "mvn clean verify -B -e -fae -Dmaven.test.failure.ignore=true -Dmaven.repo.local=$M2_REPO"
+
+    junit allowEmptyResults: true, testResults:"**/target/*-reports/*.xml"
+  }
+  
+  stage("Silver integration") {
+    // Let's test against the current, stable, development version of Silver
+    // TODO: maybe we should test against current non-stable version?
+    // i.e. /export/scratch/melt-jenkins/custom-silver ?
+    def SILVER_LATEST = "$MELT_ARTIFACTS/silver-latest.tar.gz"
+    // Unpacks to 'silver-latest/'
+    sh "tar zxvf $SILVER_LATEST"
+    
+    sh "cp target/Copper*.jar silver-latest/jars/"
+    
+    dir('silver-latest') {
+      sh "./deep-rebuild"
+    }
+  }
+  
+  if (env.BRANCH_NAME == 'develop') {
+    stage("Deploy stable") {
+      sh "cp target/Copper*.jar $MELT_ARTIFACTS/"
+    }
+  }
+
+} finally {
+  
+  // TODO: Possibly send emails to culprits? Or notify slack.
+
+}
+
+} // end node
+


### PR DESCRIPTION
This adds a script which Jenkins automatically finds, and begins building and testing Copper automatically. For all branches.

This version:

1. Builds Copper, and runs Copper's internal tests. (Additionally tracks test success/failure in Jenkins UI.)
2. Builds Silver using the new Copper artifacts, as an integration test.
3. Deploys working versions (of develop branch only) so we get the latest Copper jar in Silver releases automatically.

Presently, I haven't added anything to notify on build failures. Let me know if you like/dislike that, and I can add it in. You'll notice red X and green checks on these commits in github, those get added by Jenkins automatically.

Also let me know if you'd prefer commits get squashed. The annoying part of Jenkinsfiles is that you have to experiment on them by committing and seeing what happens. At least you can do it in branches! :)

Lastly, we unfortunately do not expose Jenkins publicly yet (thinking about it, security implications), so links from github to test failures don't work unless you're on the CS network/VPN.

This obsoletes the old-style copper build task I wrote for Jenkins.