### PR TITLE
Allow shiftable set to be accessed from subset disambiguation functions

### DIFF
--- a/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
+++ b/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
@@ -663,7 +663,7 @@ public class SingleDFAEngineBuilder
     		else first = false;
     		out.print("if(edu.umn.cs.melt.copper.runtime.auxiliary.internal.BitSetUtils.subset(match.terms,disambiguationGroups[" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "]))\n");
     		out.print("            {\n");
-    		out.print("                int result = disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(lexeme);\n");
+    		out.print("                int result = disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(lexeme, match.terms);\n");
 			out.print("                return match.terms.get(result)? result : -1;\n");
     		out.print("            }\n");
 		}
@@ -674,7 +674,14 @@ public class SingleDFAEngineBuilder
 	    
 	    for(int group = spec.disambiguationFunctions.nextSetBit(0);group >= 0;group = spec.disambiguationFunctions.nextSetBit(group+1))
 		{
-			out.print("        public int disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(final String lexeme)\n");
+	    	if (spec.df.getApplicableToSubsets(group))
+	    	{
+	    		out.print("        public int disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(final String lexeme, final " + BitSet.class.getName() + " shiftable)\n");
+	    	}
+	    	else
+	    	{
+	    		out.print("        public int disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(final String lexeme)\n");
+	    	}
 			out.print("        throws " + errorType + "\n");
 			out.print("        {\n");
 			if(spec.df.hasDisambiguateTo(group))

--- a/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
+++ b/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
@@ -640,6 +640,16 @@ public class SingleDFAEngineBuilder
 			out.print("            return RESULT;\n");
 			out.print("        }\n");
 		}
+		
+		// For use by action code in disambiguation functions for accessing the shiftable set
+		out.print("        private boolean isMember(int t, " + BitSet.class.getName() + " s)\n");
+		out.print("        {\n");
+		out.print("            return s.get(t);\n");
+		out.print("        }\n");
+		out.print("        private int nextMember(int t, " + BitSet.class.getName() + " s)\n");
+		out.print("        {\n");
+		out.print("            return s.nextSetBit(t);\n");
+		out.print("        }\n");
 
 		out.print("        public int runDisambiguationAction(" + InputPosition.class.getName() + " _pos," + SingleDFAMatchData.class.getName() + " match)\n");
 	    out.print("        throws " + IOException.class.getName() + "," + errorType + "\n");


### PR DESCRIPTION
This implements #38 as an experiment so I could test this in Silver.  Don't merge until that issue is worked out.  