### PR TITLE
Allow GlueDisambiguationFunctions to be empty in XML skin schema

### DIFF
--- a/src/edu.umn.cs.melt.copper.compiletime/src/main/resources/edu/umn/cs/melt/copper/compiletime/XMLSkin/XMLSkinSchema-0.9.xsd
+++ b/src/edu.umn.cs.melt.copper.compiletime/src/main/resources/edu/umn/cs/melt/copper/compiletime/XMLSkin/XMLSkinSchema-0.9.xsd
@@ -694,7 +694,7 @@
 					<xs:element name="GlueDisambiguationFunctions" minOccurs="0" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="DisambiguationFunctionRef" type="DisambiguationFunctionRef" minOccurs="1" maxOccurs="unbounded"/>
+								<xs:element name="DisambiguationFunctionRef" type="DisambiguationFunctionRef" minOccurs="0" maxOccurs="unbounded"/>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>


### PR DESCRIPTION
Very minor change, I'm going to merge this right away.  