### PR TITLE
Add check that returned terminal is valid for regular disambiguation functions

### DIFF
--- a/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
+++ b/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
@@ -663,7 +663,11 @@ public class SingleDFAEngineBuilder
 	    		out.print("            ");
 	    		if(!first) out.print("else ");
 	    		else first = false;
-	    		out.print("if(match.terms.equals(disambiguationGroups[" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "])) return disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(lexeme);\n");
+	    		out.print("if(match.terms.equals(disambiguationGroups[" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "]))\n");
+	    		out.print("            {\n");
+	    		out.print("                int result = disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(lexeme);\n");
+				out.print("                return match.terms.get(result)? result : -1;\n");
+	    		out.print("            }\n");
 	    	}
 		}
 	    for(int group = spec.df.getApplicableToSubsets().nextSetBit(0);group >= 0;group = spec.df.getApplicableToSubsets().nextSetBit(group+1))


### PR DESCRIPTION
This just duplicates the same check we are doing for disambiguation functions applicable to subsets, to be done on ordinary disambiguation functions as well.  Previously this wasn't needed as the only terminal identifiers visible were the ones being disambiguated, but we no longer are considering the generated `Terminals` enum "off-limits" within action blocks, so the result of a disambiguation function now requires an explicit runtime check.  The chosen behavior for both types of disambiguation functions is to raise a parse error about an unresolved lexical ambiguity, at least for now anyway.  

Fixes #43 