### PR TITLE
Minimal change for building on Java 11

### DIFF
--- a/src/edu.umn.cs.melt.copper.test/pom.xml
+++ b/src/edu.umn.cs.melt.copper.test/pom.xml
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.2</version>
         <configuration>
           <!-- Defaults: **/*Test.java, **/*Tests.java, **/Test*.java, **/*TestCase.java -->
           <excludes>
@@ -34,7 +34,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.2</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
The old version of the surefire plugin has a bug that gives a null pointer exception on Java 11. Just updating the version fixes it.

Probably, some attention should be paid to updating versions of dependencies and plugins in general, but that can wait for another day.