### PR TITLE
Allow disambiguation functions to explicitly fail by returning -1

### DIFF
--- a/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
+++ b/src/edu.umn.cs.melt.copper.compiletime/src/main/java/edu/umn/cs/melt/copper/compiletime/srcbuilders/single/SingleDFAEngineBuilder.java
@@ -666,7 +666,7 @@ public class SingleDFAEngineBuilder
 	    		out.print("if(match.terms.equals(disambiguationGroups[" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "]))\n");
 	    		out.print("            {\n");
 	    		out.print("                int result = disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(lexeme);\n");
-				out.print("                return match.terms.get(result)? result : -1;\n");
+				out.print("                return (result > 0 && match.terms.get(result))? result : -1;\n");
 	    		out.print("            }\n");
 	    	}
 		}
@@ -678,7 +678,7 @@ public class SingleDFAEngineBuilder
     		out.print("if(edu.umn.cs.melt.copper.runtime.auxiliary.internal.BitSetUtils.subset(match.terms,disambiguationGroups[" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "]))\n");
     		out.print("            {\n");
     		out.print("                int result = disambiguate_" + (group - spec.disambiguationFunctions.nextSetBit(0)) + "(lexeme, match.terms);\n");
-			out.print("                return match.terms.get(result)? result : -1;\n");
+			out.print("                return (result > 0 && match.terms.get(result))? result : -1;\n");
     		out.print("            }\n");
 		}
 		out.print("            ");


### PR DESCRIPTION
I've been doing a bit of work to finish some of the loose ends with my disambiguation class project last year.  I have run into a case where in a disambiguation class, none of the options make sense and the most useful thing is to fail with a helpful-ish error about a lexical ambiguity.  This very small change allows disambiguation functions to explicitly fail by return -1.  